### PR TITLE
All getXXX calls now accept a namespaced=False argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+*New:*
+
+    * All getXXX calls now accept a ``namespaced=False`` argument for project-independent environment keys.
+
+
 1.5.0 (2016-05-11)
 ------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -27,12 +27,13 @@ The ``ConfigGetter`` class
     :param dict defaults: Dictionary of defaults values that are fetch with the lowest priority.
                           The value for 'section.key' will be looked up at ``defaults['section']['key']``.
 
-    .. method:: getstr(key[, default=''])
+    .. method:: getstr(key[, default='', namespaced=True])
 
         Retrieve a key from available environments.
 
         :param str key: The name of the field to use.
         :param str default: The default value (string) for the field; optional
+        :param str namespaced: If the globally defined namespace must be used for this key; optional
 
         .. note:: The ``key`` param accepts two formats:
 
@@ -41,12 +42,15 @@ The ``ConfigGetter`` class
 
         This looks, in order, at:
 
-        - ``<NAMESPACE>_<SECTION>_<KEY>`` if ``section`` is set, ``<NAMESPACE>_<KEY>`` otherwise
+        - ``<NAMESPACE>_<SECTION>_<KEY>`` if ``section`` is set and ``namespaced`` is ``True``
+        - ``<NAMESPACE>_<KEY>`` if just ``namespaced`` is ``True``
+        - ``<SECTION>_<KEY>`` if just ``section`` is set
+        - ``<KEY>`` if neither ``section`` nor ``namespaced`` are set
         - The ``<key>`` entry of the ``<section>`` section of the file given in ``<NAMESPACE>_CONFIG``
         - The ``<key>`` entry of the ``<section>`` section of each file given in ``config_files``
         - The ``default`` value
 
-    .. method:: getlist(key[, default=()])
+    .. method:: getlist(key[, default=(), namespaced=True])
 
         Retrieve a key from available configuration sources, and parse it as a list.
 
@@ -66,18 +70,18 @@ The ``ConfigGetter`` class
             >>> getter.getlist('b')
             ['foo', 'bar', 'baz']
 
-    .. method:: getbool(key[, default=False])
+    .. method:: getbool(key[, default=False, namespaced=True])
 
         Retrieve a key from available configuration sources, and parse it as a boolean.
 
         The following values are considered as ``True`` : ``'on'``, ``'yes'``, ``'true'``, ``'1'``.
         Case variations of those values also count as ``True``.
 
-    .. method:: getint(key[, default=0])
+    .. method:: getint(key[, default=0, namespaced=True])
 
         Retrieve a key from available configuration sources, and parse it as an integer.
 
-    .. method:: getfloat(key[, default=0.0])
+    .. method:: getfloat(key[, default=0.0, namespaced=True])
 
         Retrieve a key from available configuration sources, and parse it as a floating point number.
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -234,6 +234,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: getter.getstr('test', 4.2))
         self.assertRaises(AssertionError, lambda: getter.getstr('test', (1, )))
 
+    def test_getstr_no_namespace(self):
+        getter = getconf.ConfigGetter('TESTNS', [])
+        with Environ(FOO='bar'):
+            self.assertEqual('bar', getter.getstr('foo', namespaced=False))
+
     def test_getlist_empty(self):
         getter = getconf.ConfigGetter('TESTNS', [])
         with Environ(TESTNS_FOO='  ,  ,,,,  '):
@@ -273,6 +278,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: getter.getlist('test', 42))
         self.assertRaises(AssertionError, lambda: getter.getlist('test', 4.2))
 
+    def test_getlist_no_namespace(self):
+        getter = getconf.ConfigGetter('TESTNS', [])
+        with Environ(FOO='bar,baz'):
+            self.assertEqual(['bar', 'baz'], getter.getlist('foo', namespaced=False))
+
     def test_getbool_empty(self):
         getter = getconf.ConfigGetter('TESTNS', [])
         with Environ(TESTNS_FOO=''):
@@ -308,6 +318,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: getter.getbool('test', 4.2))
         self.assertRaises(AssertionError, lambda: getter.getbool('test', (1, )))
 
+    def test_getbool_no_namespace(self):
+        getter = getconf.ConfigGetter('TESTNS', [])
+        with Environ(FOO='true'):
+            self.assertTrue(getter.getbool('foo', namespaced=False))
+
     def test_getint_value(self):
         getter = getconf.ConfigGetter('TESTNS', [])
         with Environ(TESTNS_FOO='14'):
@@ -326,6 +341,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: getter.getint('test', '42'))
         self.assertRaises(AssertionError, lambda: getter.getint('test', 4.2))
         self.assertRaises(AssertionError, lambda: getter.getint('test', (1, )))
+
+    def test_getint_no_namespace(self):
+        getter = getconf.ConfigGetter('TESTNS', [])
+        with Environ(FOO='34'):
+            self.assertEqual(34, getter.getint('foo', namespaced=False))
 
     def test_getfloat_value(self):
         getter = getconf.ConfigGetter('TESTNS', [])
@@ -366,6 +386,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: getter.getfloat('test', 42))
         self.assertRaises(AssertionError, lambda: getter.getfloat('test', '4.2'))
         self.assertRaises(AssertionError, lambda: getter.getfloat('test', (1, )))
+
+    def test_getfloat_no_namespace(self):
+        getter = getconf.ConfigGetter('TESTNS', [])
+        with Environ(FOO='34.2'):
+            self.assertEqual(34.2, getter.getfloat('foo', namespaced=False))
 
     def test_get_section_env(self):
         getter = getconf.ConfigGetter('TESTNS')


### PR DESCRIPTION
Useful for project-independent environment keys, like whether we are in
production or development.