### PR TITLE
Help the user to figure out which conversion raises an error

### DIFF
--- a/getconf/base.py
+++ b/getconf/base.py
@@ -258,7 +258,11 @@ class ConfigGetter(object):
         value = self._get(key, default=default, doc=doc, type_hint='int')
         if value is None:
             return None
-        return int(value)
+        try:
+            return int(value)
+        except ValueError:
+            logger.exception("Unable to cast %s as integer for the key %s.", repr(value), key)
+            raise
 
     def getfloat(self, key, default=0.0, doc=''):
         """Retrieve a value as a float."""
@@ -268,7 +272,11 @@ class ConfigGetter(object):
         value = self._get(key, default=default, doc=doc, type_hint='float')
         if value is None:
             return None
-        return float(value)
+        try:
+            return float(value)
+        except ValueError:
+            logger.exception("Unable to cast %s as float for the key %s.", repr(value), key)
+            raise
 
     def get_section(self, section_name):
         """Return a dict-like object for the chosen section."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -199,14 +199,12 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertEqual('54', getter.getstr('test'))
         self.assertEqual(54, getter.getint('test'))
 
-        if sys.version_info > (2, 7):
-            with self.assertRaises(ValueError):
-                getter.getint('wrong')
+        # Ugly test compatible with Python 2.6...
+        self.assertRaises(ValueError, getter.getint, 'wrong')
 
         self.assertEqual(54.0, getter.getfloat('test'))
-        if sys.version_info > (2, 7):
-            with self.assertRaises(ValueError):
-                getter.getfloat('wrong')
+        # Ugly test compatible with Python 2.6...
+        self.assertRaises(ValueError, getter.getfloat, 'wrong')
 
         self.assertEqual(False, getter.getbool('test'))
         self.assertEqual(['54', ], getter.getlist('test'))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -199,12 +199,14 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertEqual('54', getter.getstr('test'))
         self.assertEqual(54, getter.getint('test'))
 
-        with self.assertRaises(ValueError):
-            getter.getint('wrong')
+        if sys.version_info > (2, 7):
+            with self.assertRaises(ValueError):
+                getter.getint('wrong')
 
         self.assertEqual(54.0, getter.getfloat('test'))
-        with self.assertRaises(ValueError):
-            getter.getfloat('wrong')
+        if sys.version_info > (2, 7):
+            with self.assertRaises(ValueError):
+                getter.getfloat('wrong')
 
         self.assertEqual(False, getter.getbool('test'))
         self.assertEqual(['54', ], getter.getlist('test'))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -194,11 +194,18 @@ class ConfigGetterTestCase(unittest.TestCase):
     def test_get_defaults_dict(self):
         """Test fetching from the default config dict with non-string values."""
         warnings.warn("Use of get() directly is deprecated. Use .getstr() instead", DeprecationWarning)
-        getter = getconf.ConfigGetter('TESTNS', defaults={'DEFAULT':{"test":'54'}})
+        getter = getconf.ConfigGetter('TESTNS', defaults={'DEFAULT': {"test": '54', 'wrong': 'bad'}})
         self.assertEqual('54', getter.get('test'))
         self.assertEqual('54', getter.getstr('test'))
         self.assertEqual(54, getter.getint('test'))
+
+        with self.assertRaises(ValueError):
+            getter.getint('wrong')
+
         self.assertEqual(54.0, getter.getfloat('test'))
+        with self.assertRaises(ValueError):
+            getter.getfloat('wrong')
+
         self.assertEqual(False, getter.getbool('test'))
         self.assertEqual(['54', ], getter.getlist('test'))
 
@@ -213,7 +220,7 @@ class ConfigGetterTestCase(unittest.TestCase):
     def test_get_defaults_raises(self):
         """Test fetching from the default config dict with non-string values."""
         warnings.warn("Use of get() directly is deprecated. Use .getstr() instead", DeprecationWarning)
-        getter = getconf.ConfigGetter('TESTNS', defaults={'DEFAULT':{"test":'54'}})
+        getter = getconf.ConfigGetter('TESTNS', defaults={'DEFAULT': {"test": '54'}})
         self.assertRaises(AssertionError, lambda: getter.get('test', False))
         self.assertRaises(AssertionError, lambda: getter.get('test', 42))
         self.assertRaises(AssertionError, lambda: getter.get('test', 4.2))


### PR DESCRIPTION
Display the key of the associated value on error.

Not sure about the proper way to handle that, logger for output or better check of value before cast but you get the idea...
