### PR TITLE
Remove broken support of `LOG_TO_STDERR`.

### DIFF
--- a/getconf/base.py
+++ b/getconf/base.py
@@ -17,10 +17,7 @@ from .compat import configparser
 logger = logging.getLogger(__name__)
 
 # Avoid issue with 'no handler found for...' when called before logging setup.
-if os.environ.get('LOG_TO_STDERR', '0') == 1:
-    logger.addHandler(logging.StreamHandler())
-else:
-    logger.addHandler(compat.NullHandler())
+logger.addHandler(compat.NullHandler())
 
 
 _ConfigKey = collections.namedtuple(


### PR DESCRIPTION
Support was broken: the environment variable is always a string, never
an integer. We hence always ended up in the `else` clause. Since it
probably never worked, I guess that nobody used it. Let's remove it
altogether.