### PR TITLE
Allow the namespace to be empty

### DIFF
--- a/getconf/__init__.py
+++ b/getconf/__init__.py
@@ -7,4 +7,7 @@ __author__ = "Polyconseil <opensource+getconf@polyconseil.fr>"
 __version__ = '1.5.2'
 
 
-from .base import ConfigGetter
+from .base import (
+    ConfigGetter,
+    NO_NAMESPACE,
+)

--- a/getconf/base.py
+++ b/getconf/base.py
@@ -27,6 +27,10 @@ _ConfigKey = collections.namedtuple(
 )
 
 
+# Constant indicating that no namespace should be prefixed to environment variables.
+NO_NAMESPACE = object()
+
+
 class ConfigKey(_ConfigKey):
 
     def __hash__(self):
@@ -140,7 +144,7 @@ class ConfigGetter(object):
             args = (section, key)
         else:
             args = (key,)
-        if self.namespace:
+        if self.namespace is not NO_NAMESPACE:
             args = (self.namespace,) + args
         return '_'.join(arg.upper() for arg in args)
 

--- a/getconf/base.py
+++ b/getconf/base.py
@@ -137,9 +137,11 @@ class ConfigGetter(object):
 
     def _env_key(self, key, section=''):
         if section:
-            args = (self.namespace, section, key)
+            args = (section, key)
         else:
-            args = (self.namespace, key)
+            args = (key,)
+        if self.namespace:
+            args = (self.namespace,) + args
         return '_'.join(arg.upper() for arg in args)
 
     def _read_env(self, key):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -37,7 +37,7 @@ class Environ(object):
 
 
 class ConfigGetterTestCase(unittest.TestCase):
-    example_directory = os.path.join(os.path.dirname(__file__), 'config/')
+    example_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), 'config/'))
     example_path = os.path.join(example_directory, 'example.ini')
     example2_path = os.path.join(example_directory, 'example2.ini')
 
@@ -189,6 +189,16 @@ class ConfigGetterTestCase(unittest.TestCase):
         self.assertEqual('13', getter.getstr('section1.foo'))
 
         with Environ(TESTNS_BAR='blah', TESTNS_SECTION1_FOO='baz'):
+            self.assertEqual('blah', getter.getstr('bar'))
+            self.assertEqual('baz', getter.getstr('section1.foo'))
+
+    def test_environ_empty_namespace(self):
+        """Tests that empty namespace maps to correct environment variables."""
+        getter = getconf.ConfigGetter(None, [self.example_path])
+        self.assertEqual('42', getter.getstr('bar'))
+        self.assertEqual('13', getter.getstr('section1.foo'))
+
+        with Environ(BAR='blah', SECTION1_FOO='baz'):
             self.assertEqual('blah', getter.getstr('bar'))
             self.assertEqual('baz', getter.getstr('section1.foo'))
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -194,7 +194,7 @@ class ConfigGetterTestCase(unittest.TestCase):
 
     def test_environ_empty_namespace(self):
         """Tests that empty namespace maps to correct environment variables."""
-        getter = getconf.ConfigGetter(None, [self.example_path])
+        getter = getconf.ConfigGetter(getconf.NO_NAMESPACE, [self.example_path])
         self.assertEqual('42', getter.getstr('bar'))
         self.assertEqual('13', getter.getstr('section1.foo'))
 


### PR DESCRIPTION
I would like to be able to support an empty namespace in getconf. An empty namespace will not get added to environment variable names.

This is a backwards compatible change since specifying a namespace will still get you the current behaviour. Setting the namespace no `None` will allow you to access `section.key` using the environment variable `SECTION_KEY`. It is not possible to achieve this at the moment, since setting the namespace to the empty string would result in an underscore at the beginning: `_SECTION_KEY`.

We have a use case for not wanting namespaces: Each of our services runs in a separate Docker container (so there is almost no risk of clashing environment variables) and the services need to know how to find each other. The host:port configuration (and other config, for example database) is made available in the environment variables, for example, `SERVICE1_HOST`, `SERVICE1_PORT`, `SERVICE2_HOST`, `SERVICE2_PORT`, but this should be the same on all containers.

Conceptually, this is the same as having a `.ini` file with one section per service. We just want to be able to access those sections and keys without being forced to put a namespace in front of everything. The Docker containers implicitly provide namespacing already.
