### PR TITLE
Remove support for string interpolation in python3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,14 @@ ChangeLog
 Next version
 ------------
 
+1.6.0 (2017-02-03)
+------------------
+
+*New:*
+
+    * Remove support for string interpolation in .ini file
+      If this undocumented getconf feature is still needed by some users,
+      we might consider restoring it in a future release.
 
 1.5.2 (2017-01-23)
 ------------------

--- a/getconf/base.py
+++ b/getconf/base.py
@@ -8,8 +8,8 @@ import collections
 import datetime
 import glob
 import logging
-import warnings
 import os
+import warnings
 
 from . import compat
 from .compat import configparser
@@ -98,7 +98,7 @@ class ConfigGetter(object):
     """
 
     def __init__(self, namespace, config_files=(), defaults=None):
-        self.parser = configparser.ConfigParser()
+        self.parser = compat.get_no_interpolation_config_parser()
         self.seen_keys = set()
 
         self.namespace = namespace

--- a/getconf/compat.py
+++ b/getconf/compat.py
@@ -27,3 +27,10 @@ else:
     text_type = str
     string_types = str
     import configparser
+
+
+def get_no_interpolation_config_parser():
+    if PY2:
+        return configparser.RawConfigParser()
+    else:
+        return configparser.ConfigParser(interpolation=None)

--- a/tests/config/example.ini
+++ b/tests/config/example.ini
@@ -7,3 +7,6 @@ otherfoo = 21
 
 [encoding]
 noascii = Åuŧølīß
+
+[no-interpolation]
+nointerpolation = %(noascii)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -534,6 +534,11 @@ class ConfigGetterTestCase(unittest.TestCase):
         finally:
             os.unlink(f.name)
 
+    def test_no_interpolation(self):
+        getter = getconf.ConfigGetter('TESTNS', [self.example_path])
+        section = getter.get_section('no-interpolation')
+        self.assertEqual('%(noascii)', section['nointerpolation'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The behaviour of the default python ConfigParser changes between python2
and python3. While a value containing a percentage sign ('%') is valid
in python2, it raises a ``configparser.InterpolationSyntaxErrorerror``
in python3:

    '%' must be followed by '%' or '('')'

This commit removes interpolation support with python3.
As mentioned in the python3 documentation, with the following file:

    [Paths]
    home_dir: /Users
    my_dir: %(home_dir)s/lumberjack
    my_pictures: %(my_dir)s/Pictures

the parser would simply return %(my_dir)s/Pictures as the value of
my_pictures and %(home_dir)s/lumberjack as the value of my_dir.