### PR TITLE
base: convert dash in undescore when using environ

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ ChangeLog
 Next version
 ------------
 
+*Bugfix:*
+
+    * Allows to override a configuration containing a dash.
+
+
 1.7.0 (2017-02-23)
 ------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -32,6 +32,10 @@ The ``ConfigGetter`` class
                  are looked up under ``<SECTION>_<KEY>`` instead of ``<NAMESPACE>_<SECTION>_<KEY>``; use this setup with
                  care, since getconf might load variables that weren't intended for this application.
 
+    .. warning:: Using dash in section or key would prevent from overriding values using environment variables.
+                 Dash are converted to underscore internally, but if you have the same variable using underscore, it would
+                 override both of them.
+
     .. method:: getstr(key[, default=''])
 
         Retrieve a key from available environments.

--- a/getconf/base.py
+++ b/getconf/base.py
@@ -146,7 +146,7 @@ class ConfigGetter(object):
             args = (key,)
         if self.namespace is not NO_NAMESPACE:
             args = (self.namespace,) + args
-        return '_'.join(arg.upper() for arg in args)
+        return '_'.join(arg.upper() for arg in args).replace('-', '_')
 
     def _read_env(self, key):
         """Handle environ-related logic."""

--- a/tests/config/example.ini
+++ b/tests/config/example.ini
@@ -10,3 +10,4 @@ noascii = Åuŧølīß
 
 [no-interpolation]
 nointerpolation = %(noascii)
+with-dashes = no-dash

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -56,6 +56,15 @@ class ConfigGetterTestCase(unittest.TestCase):
             self.assertEqual('blah', getter.getstr('foo', 'foo'))
             self.assertEqual('', getter.getstr('bar'))
 
+    def test_environ_dash_declaration(self):
+        """Test when a section declaration contains a dash"""
+        getter = getconf.ConfigGetter('TESTNS', [self.example_path])
+        with Environ(TESTNS_NO_INTERPOLATION_NOINTERPOLATION="no-interpolation"):
+            self.assertEqual('no-interpolation', getter.getstr('no-interpolation.nointerpolation'))
+
+        with Environ(TESTNS_NO_INTERPOLATION_WITH_DASHES="value"):
+            self.assertEqual('value', getter.getstr('no-interpolation.with-dashes'))
+
     def test_environ_section(self):
         """Test fetching section.key from environment."""
         getter = getconf.ConfigGetter('TESTNS')


### PR DESCRIPTION
When a section title contains a dash, it was impossible to override values using environ because of shell incompatibilities
I would rather replace dash with undescore to avoid this

exemple:

$ export 'WHITERABBIT_RABBITMQ-DEFAULT_MGMT_HOST=sup-rabbitmq.intergration.local'
export: not valid in this context: WHITERABBIT_RABBITMQ-DEFAULT_MGMT_HOST