### PR TITLE
setup: fix distutils.index-servers to `pypi`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ universal = 1
 [zest.releaser]
 create-wheel = yes
 python-file-with-version = getconf/__init__.py
+
+[distutils]
+index-servers = pypi


### PR DESCRIPTION
This avoids zest upload on test or private indexes by default.