### PR TITLE
release.conf: Remove release-related Blease options

### DIFF
--- a/release.conf
+++ b/release.conf
@@ -1,8 +1,4 @@
 [Defaults]
 name = getconf
-with_wheel = 1
-changelog = ChangeLog
-version_path = getconf/__init__.py
-version_variable = __version__
 
 ; vim:set ft=dosini:


### PR DESCRIPTION
getconf uses `zest.releaser`, not Blease, to release versions.

--

I am not even sure we still need this file (and the Makefile). Shall we remove it altogether? Or replace it with a simple one that only has an `update` target that installs the requirements?