### PR TITLE
Remove mention of Blease

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,4 @@ global-exclude *.py[cod] __pycache__ *.so .*.swp *~
 
 # Be explicit to make check-manifest happy.
 exclude .pylintrc
-exclude Makefile
 exclude release.conf

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-# This Makefile requires an internal tool. Sorry.
-PACKAGE = getconf
-
-include $(shell makefile-path python.mk)
+# Don't call it "docs" otherwise Makefile confuses it with the "docs/" directory.
+doc:
+	SPHINXOPTS=-W $(MAKE) -C docs html
 
 release:
 	fullrelease
+
+test:
+	nosetests
+
+update:
+	pip install -r requirements_dev.txt

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,13 +13,10 @@ To run tests:
 
     nosetests
 
-To make a release, use the ``release`` target:
+To make a release:
 
 .. code-block:: sh
 
-    make release
-
-which relies on `zest.releaser`_.
-
+    fullrelease
 
 .. _zest.releaser: https://zestreleaser.readthedocs.io/en/latest/index.html

--- a/release.conf
+++ b/release.conf
@@ -1,8 +1,0 @@
-[Defaults]
-name = getconf
-with_wheel = 1
-changelog = ChangeLog
-version_path = getconf/__init__.py
-version_variable = __version__
-
-; vim:set ft=dosini:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 -e .
 
 Sphinx>=1.3
+sphinx_rtd_theme
 pylint
 nose
 coverage


### PR DESCRIPTION
Blease is an internal tool. We don't use it on getconf anymore: builds
are run on Travis (and we don't use Blease there, obviously), and
releases are made with `zest.releaser`.