### PR TITLE
setup.cfg: Include license file in the sdist/wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_files = LICENSE
+
 [bdist_wheel]
 universal = 1
 


### PR DESCRIPTION
This is required by the license.

See
https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
and https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

Spotted by Xavier Fernandez.