### PR TITLE
Add support for pathlib.Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist/
 htmlcov/
 reports/
 MANIFEST
+
+# Dev tools
+.vscode/

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,12 @@ ChangeLog
 =========
 
 1.10.0 (unreleased)
-------------------
+-------------------
+
+*New:*
+
+    * Add support of pathlib.Path objects, both in loading the config
+      and through the new ``getpath`` getter.
 
 *New:*
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Links
 Installation
 ------------
 
-Intall the package from `PyPI`_, using pip:
+Install the package from `PyPI`_, using pip:
 
 .. code-block:: sh
 
@@ -73,7 +73,7 @@ Or from GitHub:
     git clone git://github.com/Polyconseil/getconf
 
 
-``getconf`` has no external dependancy beyond Python.
+``getconf`` has no external dependency beyond Python.
 
 
 Introduction
@@ -144,6 +144,8 @@ Features
         config.getint('db.port', 5432)
         config.getlist('db.tables')  # Expects a comma-separated list
         config.getfloat('db.auto_vacuum_scale_factor', 0.2)
+        config.gettimedelta('account_activation.validity', '2d')
+        config.getpath('django.static_root', pathlib.Path(BASE_DIR / 'static'))
 
 Concepts
 --------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,7 +4,7 @@ Advanced use
 getconf supports some more complex setups; this document describes advanced options.
 
 
-Recommanded layout
+Recommended layout
 ------------------
 
 Managing configuration can quickly turn into hell; here are a few guidelines:
@@ -112,7 +112,7 @@ this is strictly equivalent to using ``config = getconf.ConfigGetter('myproj', [
           when using a folder, we want definitions from ``99_overrides`` to override those in ``00_base``.
 
 
-Precedency
+Precedence
 ----------
 
 When reading configuration from multiple sources, it can be complex to determine which source overrides which.
@@ -125,7 +125,7 @@ When reading configuration from multiple sources, it can be complex to determine
 
 Two special cases need to be handled:
 
-- The environment-provided configuration file (``<NAMESPACE>_CONFIG``) has precedency over configuration files declared in ``ConfigGetter(config_files=[])``
+- The environment-provided configuration file (``<NAMESPACE>_CONFIG``) has precedence over configuration files declared in ``ConfigGetter(config_files=[])``
 - When a configuration file is actually a directory (even if provided through ``<NAMESPACE>_CONFIG``),
   its directly contained files are inserted in **ALPHABETICAL ORDER**, so that ``99_foo``
   actually overrides ``10_base``.

--- a/docs/goals.rst
+++ b/docs/goals.rst
@@ -54,7 +54,7 @@ Customization:
 Other options
 -------------
 
-While desiging ``getconf``, we looked at other options:
+While designing ``getconf``, we looked at other options:
 
 Define everything in files
     * This makes it difficult to override a single setting (where should the file be?)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,7 +14,7 @@ The ``BaseConfigGetter`` class
                            Finders are python objects providing the ``find(key)`` method that will be called in
                            the order the ``config_finders`` were provided order until one of them finds the ``key``.
                            The ``find(key)`` method should either return a string or raise ``NotFound`` depending
-                           on wheither the ``key`` was found or not.
+                           on whether the ``key`` was found or not.
 
     :param key_validator: If provided, ``key_validator`` must be a callable that raises ``InvalidKey`` on invalid keys.
 
@@ -76,6 +76,10 @@ The ``BaseConfigGetter`` class
 
         Retrieve a key from available configuration sources, and parse it as a datetime.timedelta object.
 
+    .. py:method:: getpath(key[, default=Path('.')])
+
+        Retrieve a key from available configuration sources, and parse it as a pathlib.Path object.
+
 
 The ``ConfigGetter`` class
 ---------------------------
@@ -92,6 +96,7 @@ The ``ConfigGetter`` class
                               Each item may either be the path to a simple file, or to a directory
                               (if the path ends with a '/') or a glob pattern (which will select all the files
                               matching the pattern according to the rules used by the shell).
+                              Both strings and pathlib.Path objects are accepted.
                               Each directory path will be replaced by the list of
                               its directly contained files, in alphabetical order, excluding those whose name
                               starts with a '.'.

--- a/getconf/base.py
+++ b/getconf/base.py
@@ -5,6 +5,7 @@ import collections
 import datetime
 import logging
 import operator
+from pathlib import Path
 import warnings
 
 from . import finders
@@ -177,6 +178,19 @@ class BaseConfigGetter:
             raise ValueError(fmt % args)
         else:
             return datetime.timedelta(**{unit: value})
+
+    def getpath(self, key, default=Path('.'), doc=''):
+        assert (
+            default is None or isinstance(default, (Path, str))
+        ), 'getpath("%s", %r) has an invalid default value type.' % (key, default)
+        value = self._get(key, default=default, doc=doc, type_hint='pathlib.Path')
+        if value is None:
+            return None
+        try:
+            return Path(value)
+        except TypeError:  # not raising ValueError
+            logger.exception("Unable to cast %r as Path for the key %s.", value, key)
+            raise
 
 
 def section_validator(key):

--- a/getconf/finders.py
+++ b/getconf/finders.py
@@ -111,7 +111,7 @@ class MultiINIFilesParserFinder:
             if path is None:
                 continue
             # Handle '~/.foobar.conf'
-            path = os.path.abspath(os.path.expanduser(path))
+            path = os.path.abspath(os.path.expanduser(str(path)))
             if os.path.isdir(path):
                 path = os.path.join(path, '*')
 


### PR DESCRIPTION
Django 3.0 and even more 3.1 accepts Paths everywhere.

Before:

    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
    CONFIG = getconf.ConfigGetter(
        PROJECT_NAME, [os.path.join(BASE_DIR, "local_settings.ini")]
    )
    STATIC_ROOT = CONFIG.getstr("django.static_root", os.path.join(BASE_DIR, "static"))

After:

    BASE_DIR = Path(__file__).resolve().parent.parent
    CONFIG = getconf.ConfigGetter(PROJECT_NAME, [BASE_DIR / "local_settings.ini"])
    STATIC_ROOT = CONFIG.getstr("django.static_root", BASE_DIR / "static")

Pathlib could also be used within the tests and implementation, but it was
left away for a future revision.

No particular linting convention seems to be applied, so I deactivated
it in my editor.

Edit: used the `BASE_DIR` pattern from a new Django 3.1 project. Mine just didn't work in production.